### PR TITLE
Add prints of read dt props

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -446,7 +446,9 @@ def generate_driver(p: Panel, options: Options) -> None:
 
 		flag = GpioFlag.ACTIVE_HIGH
 		last_val, _ = p.reset_seq[-1]
+		print(f"checking {last_val} for reset active_low")
 		if last_val == 1:
+			print("active low it is!!")
 			flag = GpioFlag.ACTIVE_LOW
 
 		options.gpios["reset"] = flag


### PR DESCRIPTION
For some vendors, the DT properties differ a lot from what is expected by the script. Print all properties that are read, to ease with debugging/porting vendor DT to script-compatible DT.

I guess all prints can be enabled/disabled with a cmd option? Let me know.