### PR TITLE
Add common helper from msm8953

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -19,6 +19,7 @@ class Options:
 	backlight_gpio: bool
 	dcs_get_brightness: bool
 	ignore_wait: int
+	use_helper: bool
 	dumb_dcs: bool
 
 	# Added by panel driver generator

--- a/lmdpdg.py
+++ b/lmdpdg.py
@@ -51,6 +51,9 @@ parser.add_argument('--ignore-wait', type=int, default=0, help="""
 	Some device trees add a useless 1ms wait after each command, making the driver
 	unnecessarily verbose.
 """)
+parser.add_argument('--use-helper', dest='use_helper', action='store_true', help="""
+	Use common driver helper.
+""")
 parser.add_argument('--dumb-dcs', dest='dumb_dcs', action='store_true', help="""
 	Do not attempt to interpret DCS commands. Some panels use arbitrary DCS commands
 	to write to registers, which conflict with commands specified in the MIPI DCS

--- a/simple.py
+++ b/simple.py
@@ -22,6 +22,21 @@ static const struct drm_display_mode {p.short_id}_mode = {{
 }};
 '''
 
+def generate_mode_common(p: Panel) -> str:
+	return f'''\
+	.mode = {{
+		.clock = ({p.h.px} + {p.h.fp} + {p.h.pw} + {p.h.bp}) * ({p.v.px} + {p.v.fp} + {p.v.pw} + {p.v.bp}) * {p.framerate} / 1000,
+		.hdisplay = {p.h.px},
+		.hsync_start = {p.h.px} + {p.h.fp},
+		.hsync_end = {p.h.px} + {p.h.fp} + {p.h.pw},
+		.htotal = {p.h.px} + {p.h.fp} + {p.h.pw} + {p.h.bp},
+		.vdisplay = {p.v.px},
+		.vsync_start = {p.v.px} + {p.v.fp},
+		.vsync_end = {p.v.px} + {p.v.fp} + {p.v.pw},
+		.vtotal = {p.v.px} + {p.v.fp} + {p.v.pw} + {p.v.bp},
+		.width_mm = {p.h.size},
+		.height_mm = {p.v.size},
+	}},'''
 
 def generate_panel_simple(p: Panel) -> None:
 	name = p.short_id.replace('_', '-')


### PR DESCRIPTION
There has been a fork of this project and one commit has beed added. Have been told that usage of common helper will reduce generated code -> lead to smaller code base of driver. Could be a good feature. There is no need to split teams and spirit. Only one generator should be maintained and active as project.If this commit will pass, then msm8953  fork could be deleted and usage of msm8916 generator could be advised as all code will be here.

Origin of commit source:
https://github.com/msm8953-mainline/linux-mdss-dsi-panel-driver-generator

Edit:
Not in msm8916-mainline. Could be eventually be merged if upstreamed from msm8953-mainline

