### PR TITLE
lk: Add basic panel header generator for LK bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ The generator has a couple of command line options that can be used to generate
 additional code (e.g. to enable a regulator to power on the panel).
 The script will gladly inform you about available options if you pass `--help`.
 
+Currently there are 4 files generated:
+  - `panel-xyz.c`: The main (full) panel driver for Linux.
+  - `panel-simple-xyz.c`: A snippet to use for `panel-simple.c` in Linux.
+    Can be used if the full panel driver is causing problems.
+  - `panel-xyz.dtsi`: An example for the relevant panel setup in the device tree.
+  - `lk_panel_xyz.h`: A panel header for Qualcomm's Little Kernel (LK) bootloader.
+    Can be used to turn the display on for splash screens there.
+
 ### Making final edits
 In most cases, the driver should work as-is, no changes required.
 If you would like to use it permanently, or even upstream it, here are a few

--- a/dtsi.py
+++ b/dtsi.py
@@ -51,3 +51,10 @@ def generate_panel_dtsi(p: Panel, options: Options) -> None:
 	remote-endpoint = <&panel_in>;
 }};
 ''')
+
+		if p.ldo_mode:
+			f.write('''
+&dsi_phy0 {
+	qcom,dsi-phy-regulator-ldo-mode;
+};
+''')

--- a/lk.py
+++ b/lk.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: GPL-2.0-only
+from __future__ import annotations
+
+import datetime
+
+import wrap
+from panel import Panel, Mode, CommandSequence, LaneMap, TrafficMode
+
+
+def generate_commands(p: Panel, cmd_name: str) -> str:
+	cmd: CommandSequence = p.cmds[cmd_name]
+
+	cmds = ""
+	struct = f"static struct mipi_dsi_cmd {p.id}_{cmd_name}_command[] = {{\n"
+
+	s = ""
+	i = 0
+	for c in cmd.seq:
+		b = bytearray()
+		long = c.type.is_long
+		if long:
+			b += int.to_bytes(len(c.payload), 2, 'little')  # Word count (WC)
+		else:
+			assert len(c.payload) <= 2, f"Payload too long: {len(c.payload)}"
+			itr = iter(c.payload)
+			b.append(next(itr, 0))
+			b.append(next(itr, 0))
+
+		b.append(c.type.value | c.vc << 6)
+		b.append(int(c.ack) << 5 | int(long) << 6 | int(c.last) << 7)
+
+		if long:
+			b += bytes(c.payload)
+
+			# DMA command size must be multiple of 4
+			mod = len(b) % 4
+			if mod != 0:
+				b += bytes([0xff] * (4 - mod))
+
+		name = f'{p.id}_{cmd_name}_cmd_{i}'
+		cmds += f'static char {name}[] = {{\n'
+		cmds += wrap.join('\t', ',', '', [f'{byte:#04x}' for byte in b], wrap=54)
+		cmds += '\n};\n'
+
+		struct += f'\t{{ sizeof({name}), {name}, {c.wait} }},\n'
+		i += 1
+
+	struct += '};'
+
+	return cmds + '\n' + struct
+
+
+def generate_cmd_info(p: Panel) -> str:
+	s = f'static struct commandpanel_info {p.id}_command_panel = {{\n'
+	if p.mode != Mode.CMD_MODE:
+		return s + '\t/* Unused, this is a video mode panel */\n};'
+
+	s += '\t/* FIXME: This is a command mode panel */\n'
+	return s + '};'
+
+
+def generate_video_info(p: Panel) -> str:
+	s = f'static struct videopanel_info {p.id}_video_panel = {{\n'
+
+	s += f'''\
+	.hsync_pulse = {int('MIPI_DSI_MODE_VIDEO_HSE' in p.flags)},
+	.hfp_power_mode = {int(p.hfp_power_mode)},
+	.hbp_power_mode = {int(p.hbp_power_mode)},
+	.hsa_power_mode = {int(p.hsa_power_mode)},
+	.bllp_eof_power_mode = {int(p.bllp_eof_power_mode)},
+	.bllp_power_mode = {int(p.bllp_power_mode)},
+	.traffic_mode = {list(TrafficMode.__members__.values()).index(p.traffic_mode)},
+	/* This is bllp_eof_power_mode and bllp_power_mode combined */
+	.bllp_eof_power = {int(p.bllp_eof_power_mode)} << 3 | {int(p.bllp_power_mode)} << 0,
+'''
+	return s + '};'
+
+
+def generate_reset_seq(p: Panel) -> str:
+	if not p.reset_seq:
+		return ''
+
+	return f'''
+static struct panel_reset_sequence {p.id}_reset_seq = {{
+	.pin_state = {{ {', '.join(str(res[0]) for res in p.reset_seq)} }},
+	.sleep = {{ {', '.join(str(res[1]) for res in p.reset_seq)} }},
+	.pin_direction = 2,
+}};
+'''
+
+
+def generate_backlight(p: Panel) -> str:
+	if not p.backlight:
+		return ''
+
+	return f'''
+static struct backlight {p.id}_backlight = {{
+	.bl_interface_type = BL_{p.backlight.name},
+	.bl_min_level = 1,
+	.bl_max_level = {p.max_brightness},
+}};
+'''
+
+
+def generate_lk_driver(p: Panel) -> None:
+	if 'sim' in p.id:
+		return
+
+	define = f'_PANEL_{p.id.upper()}_H_'
+
+	with open(f'{p.id}/lk_panel_{p.id}.h', 'w') as f:
+		f.write(f'''\
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) {datetime.date.today().year} FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2014, The Linux Foundation. All rights reserved. (FIXME)
+
+#ifndef {define}
+#define {define}
+
+#include <mipi_dsi.h>
+#include <panel_display.h>
+#include <panel.h>
+#include <string.h>
+
+static struct panel_config {p.id}_panel_data = {{
+	.panel_node_id = "{p.node_name}",
+	.panel_controller = "dsi:0",
+	.panel_compatible = "qcom,mdss-dsi-panel",
+	.panel_type = {int(p.mode == Mode.CMD_MODE)},
+	.panel_destination = "DISPLAY_1",
+	/* .panel_orientation not supported yet */
+	.panel_framerate = {p.framerate},
+	.panel_lp11_init = {int(p.lp11_init)},
+	.panel_init_delay = {p.init_delay},
+}};
+
+static struct panel_resolution {p.id}_panel_res = {{
+	.panel_width = {p.h.px},
+	.panel_height = {p.v.px},
+	.hfront_porch = {p.h.fp},
+	.hback_porch = {p.h.bp},
+	.hpulse_width = {p.h.pw},
+	.hsync_skew = {p.hsync_skew},
+	.vfront_porch = {p.v.fp},
+	.vback_porch = {p.v.bp},
+	.vpulse_width = {p.v.pw},
+	/* Borders not supported yet */
+}};
+
+static struct color_info {p.id}_color = {{
+	.color_format = {p.bpp},
+	.color_order = DSI_RGB_SWAP_RGB,
+	.underflow_color = 0xff,
+	/* Borders and pixel packing not supported yet */
+}};
+
+{generate_commands(p, 'on')}
+
+{generate_commands(p, 'off')}
+
+static struct command_state {p.id}_state = {{
+	.oncommand_state = {int(p.cmds['on'].state == CommandSequence.State.HS_MODE)},
+	.offcommand_state = {int(p.cmds['off'].state == CommandSequence.State.HS_MODE)},
+}};
+
+{generate_cmd_info(p)}
+
+{generate_video_info(p)}
+
+static struct lane_configuration {p.id}_lane_config = {{
+	.dsi_lanes = {p.lanes},
+	.dsi_lanemap = {list(LaneMap.__members__.values()).index(p.lane_map)},
+	.lane0_state = {int(p.lanes > 0)},
+	.lane1_state = {int(p.lanes > 1)},
+	.lane2_state = {int(p.lanes > 2)},
+	.lane3_state = {int(p.lanes > 3)},
+	.force_clk_lane_hs = {int('MIPI_DSI_CLOCK_NON_CONTINUOUS' not in p.flags)},
+}};
+
+static const uint32_t {p.id}_timings[] = {{
+	{', '.join(f'{byte:#04x}' for byte in p.timings)}
+}};
+
+static struct panel_timing {p.id}_timing_info = {{
+	.tclk_post = {p.tclk_post:#04x},
+	.tclk_pre = {p.tclk_pre:#04x},
+}};
+{generate_reset_seq(p)}{generate_backlight(p)}
+{wrap.join(f'static inline void panel_{p.id}_select(', ',', ')',
+		   ['struct panel_struct *panel', 'struct msm_panel_info *pinfo',
+			'struct mdss_dsi_phy_ctrl *phy_db'])}
+{{
+	panel->paneldata = &{p.id}_panel_data;
+	panel->panelres = &{p.id}_panel_res;
+	panel->color = &{p.id}_color;
+	panel->videopanel = &{p.id}_video_panel;
+	panel->commandpanel = &{p.id}_command_panel;
+	panel->state = &{p.id}_state;
+	panel->laneconfig = &{p.id}_lane_config;
+	panel->paneltiminginfo = &{p.id}_timing_info;
+	panel->panelresetseq = {f'&{p.id}_reset_seq' if p.reset_seq else 'NULL'};
+	panel->backlightinfo = {f'&{p.id}_backlight' if p.backlight else 'NULL'};
+	pinfo->mipi.panel_cmds = {p.id}_on_command;
+	pinfo->mipi.num_of_panel_cmds = ARRAY_SIZE({p.id}_on_command);
+	memcpy(phy_db->timing, {p.id}_timings, TIMING_SIZE);
+	phy_db->regulator_mode = {'DSI_PHY_REGULATOR_LDO_MODE' if p.ldo_mode else 'DSI_PHY_REGULATOR_DCDC_MODE'};
+}}
+
+#endif /* {define} */
+''')

--- a/lmdpdg.py
+++ b/lmdpdg.py
@@ -10,6 +10,7 @@ import generator
 from driver import generate_driver
 from dtsi import generate_panel_dtsi
 from fdt2 import Fdt2
+from lk import generate_lk_driver
 from panel import Panel
 from simple import generate_panel_simple
 
@@ -27,6 +28,7 @@ def generate(p: Panel, options: generator.Options) -> None:
 	generate_panel_simple(p)
 	generate_driver(p, options)
 	generate_panel_dtsi(p, options)
+	generate_lk_driver(p)
 
 
 parser = argparse.ArgumentParser(

--- a/mipi.py
+++ b/mipi.py
@@ -10,6 +10,12 @@
 # Copyright (C) 2006 Nokia Corporation
 # Author: Imre Deak <imre.deak@nokia.com>
 #
+# Some code adapted from:
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/drm_mipi_dsi.c
+#
+# Copyright (C) 2012-2013, Samsung Electronics, Co., Ltd.
+# Andrzej Hajda <a.hajda@samsung.com>
+#
 from __future__ import annotations
 
 from enum import IntEnum, unique, Enum
@@ -295,6 +301,28 @@ class Transaction(Enum):
 	@property
 	def description(self):
 		return self.name.lower().replace('_', ' ')
+
+	@property
+	def is_long(self):
+		# From mipi_dsi_packet_format_is_long()
+		return self in [
+			Transaction.NULL_PACKET,
+			Transaction.BLANKING_PACKET,
+			Transaction.GENERIC_LONG_WRITE,
+			Transaction.DCS_LONG_WRITE,
+			Transaction.PICTURE_PARAMETER_SET,
+			Transaction.COMPRESSED_PIXEL_STREAM,
+			Transaction.LOOSELY_PACKED_PIXEL_STREAM_YCBCR20,
+			Transaction.PACKED_PIXEL_STREAM_YCBCR24,
+			Transaction.PACKED_PIXEL_STREAM_YCBCR16,
+			Transaction.PACKED_PIXEL_STREAM_30,
+			Transaction.PACKED_PIXEL_STREAM_36,
+			Transaction.PACKED_PIXEL_STREAM_YCBCR12,
+			Transaction.PACKED_PIXEL_STREAM_16,
+			Transaction.PACKED_PIXEL_STREAM_18,
+			Transaction.PIXEL_STREAM_3BYTE_18,
+			Transaction.PACKED_PIXEL_STREAM_24,
+		]
 
 	def generate(self, payload: bytes, options: Options) -> str:
 		return self._generate(self, payload, options)

--- a/mipi.py
+++ b/mipi.py
@@ -236,6 +236,9 @@ class Transaction(Enum):
 	H_SYNC_START = 0x21,
 	H_SYNC_END = 0x31,
 
+	COMPRESSION_MODE = 0x07,
+	END_OF_TRANSMISSION = 0x08,
+
 	COLOR_MODE_OFF = 0x02,
 	COLOR_MODE_ON = 0x12,
 	SHUTDOWN_PERIPHERAL = 0x22, 0, _generate_peripheral
@@ -253,18 +256,17 @@ class Transaction(Enum):
 	DCS_SHORT_WRITE_PARAM = 0x15, 1, _generate_dcs_write
 
 	DCS_READ = 0x06,
-
-	DCS_COMPRESSION_MODE = 0x07,
-	PPS_LONG_WRITE = 0x0A,
+	EXECUTE_QUEUE = 0x16,
 
 	SET_MAXIMUM_RETURN_PACKET_SIZE = 0x37, -1, _generate_ignore
-
-	END_OF_TRANSMISSION = 0x08,
 
 	NULL_PACKET = 0x09, -1, _generate_ignore
 	BLANKING_PACKET = 0x19,
 	GENERIC_LONG_WRITE = 0x29, -1, _generate_generic_write
 	DCS_LONG_WRITE = 0x39, -1, _generate_dcs_write
+
+	PICTURE_PARAMETER_SET = 0x0a,
+	COMPRESSED_PIXEL_STREAM = 0x0b,
 
 	LOOSELY_PACKED_PIXEL_STREAM_YCBCR20 = 0x0c,
 	PACKED_PIXEL_STREAM_YCBCR24 = 0x1c,

--- a/panel.py
+++ b/panel.py
@@ -276,6 +276,13 @@ class Panel:
 			self.h.size = phy_size_mm[0]
 			self.v.size = phy_size_mm[1]
 
+		# Check DSI controller if LDO mode is needed
+		self.ldo_mode = False
+		dsi_ctrl = fdt.getprop_int32(node, 'qcom,mdss-dsi-panel-controller')
+		if dsi_ctrl is not None:
+			dsi_ctrl = fdt.node_offset_by_phandle(dsi_ctrl)
+			self.ldo_mode = fdt.getprop_or_none(dsi_ctrl, 'qcom,regulator-ldo-mode') is not None
+
 	@staticmethod
 	def parse(fdt: Fdt2, node: int) -> Panel:
 		name = fdt.getprop_or_none(node, 'qcom,mdss-dsi-panel-name')


### PR DESCRIPTION
Add a basic panel header generator for Qualcomm's LK bootloader so it's easier to initialize displays already in a custom bootloader.