### PR TITLE
Support panels under qcom,sde-kms

### DIFF
--- a/panel.py
+++ b/panel.py
@@ -322,6 +322,10 @@ class Panel:
 			for sub in fdt.subnodes(mdp):
 				yield sub
 
+		for mdp in fdt.find_by_compatible('qcom,sde-kms'):
+			for sub in fdt.subnodes(mdp):
+				yield sub
+
 		# Newer device trees do not necessarily have panels below MDP,
 		# search for qcom,dsi-display node instead
 		panel_phandles = set()
@@ -330,7 +334,9 @@ class Panel:
 			# On even newer SoCs there is another node with qcom,dsi-display-list
 			displays = fdt.getprop_or_none(display, 'qcom,dsi-display-list')
 			if displays is None:
-				panel_phandles.add(fdt.getprop(display, 'qcom,dsi-panel').as_uint32())
+				dsi_panel = fdt.getprop_or_none(display, 'qcom,dsi-panel')
+				if dsi_panel is not None:
+					panel_phandles.add(dsi_panel.as_uint32())
 			else:
 				for display_phandle in displays.as_uint32_array():
 					display = fdt.node_offset_by_phandle(display_phandle)


### PR DESCRIPTION
The structure changed again for new SoCs, like on fairphone-fp4.

Test dtb (zipped because github..): [fp4.dtb.zip](https://github.com/msm8916-mainline/linux-mdss-dsi-panel-driver-generator/files/8755082/fp4.dtb.zip)