### PR TITLE
driver: Make remove callback return void

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -525,7 +525,7 @@ static const struct drm_panel_funcs {p.short_id}_panel_funcs = {{
 }};
 
 {generate_backlight(p, options)}{generate_probe(p, options)}
-static int {p.short_id}_remove(struct mipi_dsi_device *dsi)
+static void {p.short_id}_remove(struct mipi_dsi_device *dsi)
 {{
 	struct {p.short_id} *ctx = mipi_dsi_get_drvdata(dsi);
 	int ret;
@@ -535,8 +535,6 @@ static int {p.short_id}_remove(struct mipi_dsi_device *dsi)
 		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\\n", ret);
 
 	drm_panel_remove(&ctx->panel);
-
-	return 0;
 }}
 
 static const struct of_device_id {p.short_id}_of_match[] = {{


### PR DESCRIPTION
As per upstream changes for 6.1:
https://git.kernel.org/torvalds/c/79abca2