### PR TITLE
Support DSC (Display Stream Compression) panels

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -457,7 +457,9 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 	// TODO: Pass slice_per_pkt = {p.dsc_slice_per_pkt}
 	dsc->slice_height = {p.dsc_slice_height};
 	dsc->slice_width = {p.dsc_slice_width};
-	dsc->slice_count = 1; // TODO: fix this value
+	// TODO: Get hdisplay from the mode
+	BUG_ON({p.h.px} % dsc->slice_width);
+	dsc->slice_count = {p.h.px} / dsc->slice_width;
 	dsc->bits_per_component = {p.dsc_bit_per_component};
 	dsc->bits_per_pixel = {p.dsc_bit_per_pixel};
 	dsc->block_pred_enable = {"true" if p.dsc_dsc_block_prediction else "false"};

--- a/driver.py
+++ b/driver.py
@@ -445,13 +445,6 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 
 	s += '''
 	drm_panel_add(&ctx->panel);
-
-	ret = mipi_dsi_attach(dsi);
-	if (ret < 0) {
-		dev_err(dev, "Failed to attach to DSI host: %d\\n", ret);
-		drm_panel_remove(&ctx->panel);
-		return ret;
-	}
 '''
 
 	if p.has_dsc:
@@ -474,6 +467,15 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 	ctx->dsc.bits_per_component = {p.dsc_bit_per_component};
 	ctx->dsc.bits_per_pixel = {p.dsc_bit_per_pixel} << 4; /* 4 fractional bits */
 	ctx->dsc.block_pred_enable = {"true" if p.dsc_dsc_block_prediction else "false"};
+'''
+
+	s += '''
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
 '''
 
 	s += '''

--- a/driver.py
+++ b/driver.py
@@ -32,7 +32,8 @@ def generate_includes(p: Panel, options: Options) -> str:
 	if p.backlight == BacklightControl.DCS or options.backlight_fallback_dcs:
 		includes['linux'].add('backlight.h')
 	if p.has_dsc:
-		includes['drm'].add('drm_dsc.h')
+		includes['drm'].add('display/drm_dsc.h')
+		includes['drm'].add('display/drm_dsc_helper.h')
 
 	for cmd in p.cmds.values():
 		if 'MIPI_DCS_' in cmd.generated:
@@ -230,6 +231,7 @@ static int {p.short_id}_prepare(struct drm_panel *panel)
 	ctx->prepared = true;
 
 	return 0;
+}
 '''
 	return s
 

--- a/driver.py
+++ b/driver.py
@@ -454,6 +454,7 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 	dsc->dsc_version_major = {p.dsc_version};
 	dsc->dsc_version_minor = {p.dsc_scr_version};
 
+	// TODO: Pass slice_per_pkt = {p.dsc_slice_per_pkt}
 	dsc->slice_height = {p.dsc_slice_height};
 	dsc->slice_width = {p.dsc_slice_width};
 	dsc->slice_count = 1; // TODO: fix this value

--- a/driver.py
+++ b/driver.py
@@ -452,8 +452,8 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 	/* This panel only supports DSC; unconditionally enable it */
 	dsi->dsc = &ctx->dsc;
 
-	ctx->dsc.dsc_version_major = {p.dsc_version};
-	ctx->dsc.dsc_version_minor = {p.dsc_scr_version};
+	ctx->dsc.dsc_version_major = {(p.dsc_version >> 4) & 0xf};
+	ctx->dsc.dsc_version_minor = {p.dsc_version & 0xf};
 
 	/* TODO: Pass slice_per_pkt = {p.dsc_slice_per_pkt} */
 	ctx->dsc.slice_height = {p.dsc_slice_height};

--- a/driver.py
+++ b/driver.py
@@ -216,6 +216,13 @@ static int {p.short_id}_prepare(struct drm_panel *panel)
 		drm_dsc_pps_payload_pack(&pps, ctx->dsi->dsc);
 		print_hex_dump(KERN_DEBUG, "DSC params:", DUMP_PREFIX_NONE,
 			       16, 1, &pps, sizeof(pps), false);
+
+		ret = mipi_dsi_picture_parameter_set(ctx->dsi, &pps);
+		if (ret < 0) {
+			dev_err(panel->dev, "failed to set pps: %d\\n", ret);
+			return ret;
+		}
+		msleep(28); /* TODO: Is this panel-dependent? */
 	}
 '''
 

--- a/driver.py
+++ b/driver.py
@@ -213,16 +213,20 @@ static int {p.short_id}_prepare(struct drm_panel *panel)
 	if p.has_dsc:
 		s += '''
 	if (ctx->dsi->dsc) {
-		/* this panel uses DSC so send the pps */
 		drm_dsc_pps_payload_pack(&pps, ctx->dsi->dsc);
-		print_hex_dump(KERN_DEBUG, "DSC params:", DUMP_PREFIX_NONE,
-			       16, 1, &pps, sizeof(pps), false);
 
 		ret = mipi_dsi_picture_parameter_set(ctx->dsi, &pps);
 		if (ret < 0) {
-			dev_err(panel->dev, "failed to set pps: %d\\n", ret);
+			dev_err(panel->dev, "failed to transmit PPS: %d\\n", ret);
 			return ret;
 		}
+
+		ret = mipi_dsi_compression_mode(ctx->dsi, true);
+		if (ret < 0) {
+			dev_err(dev, "failed to enable compression mode: %d\\n", ret);
+			return ret;
+		}
+
 		msleep(28); /* TODO: Is this panel-dependent? */
 	}
 '''

--- a/driver.py
+++ b/driver.py
@@ -461,7 +461,7 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 	BUG_ON({p.h.px} % dsc->slice_width);
 	dsc->slice_count = {p.h.px} / dsc->slice_width;
 	dsc->bits_per_component = {p.dsc_bit_per_component};
-	dsc->bits_per_pixel = {p.dsc_bit_per_pixel};
+	dsc->bits_per_pixel = {p.dsc_bit_per_pixel} << 4; /* 4 fractional bits */
 	dsc->block_pred_enable = {"true" if p.dsc_dsc_block_prediction else "false"};
 
 	pinfo->base.dsc = dsc;

--- a/driver.py
+++ b/driver.py
@@ -211,11 +211,11 @@ static int {p.short_id}_prepare(struct drm_panel *panel)
 
 	if p.has_dsc:
 		s += '''
-	if (panel->dsc) {
+	if (ctx->dsi->dsc) {
 		/* this panel uses DSC so send the pps */
-		drm_dsc_pps_payload_pack(&pps, panel->dsc);
+		drm_dsc_pps_payload_pack(&pps, ctx->dsi->dsc);
 		print_hex_dump(KERN_DEBUG, "DSC params:", DUMP_PREFIX_NONE,
-                               16, 1, &pps, sizeof(pps), false);
+			       16, 1, &pps, sizeof(pps), false);
 	}
 '''
 
@@ -464,7 +464,7 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 	dsc->bits_per_pixel = {p.dsc_bit_per_pixel} << 4; /* 4 fractional bits */
 	dsc->block_pred_enable = {"true" if p.dsc_dsc_block_prediction else "false"};
 
-	pinfo->base.dsc = dsc;
+	dsi->dsc = dsc;
 '''
 
 	s += '''

--- a/driver.py
+++ b/driver.py
@@ -460,7 +460,7 @@ static int {p.short_id}_probe(struct mipi_dsi_device *dsi)
 
 	if p.has_dsc:
 		s += f'''
-	dsc = devm_kzalloc(&dsi->dev, sizeof(*dsc), GFP_KERNEL);
+	dsc = devm_kzalloc(dev, sizeof(*dsc), GFP_KERNEL);
 	if (!dsc)
 		return -ENOMEM;
 

--- a/panel.py
+++ b/panel.py
@@ -308,6 +308,39 @@ class Panel:
 		self.lp11_init = fdt.getprop_or_none(node, 'qcom,mdss-dsi-lp11-init') is not None
 		self.init_delay = fdt.getprop_uint32(node, 'qcom,mdss-dsi-init-delay-us')
 
+		# Display Stream Compression
+		self.compression_mode = fdt.getprop_or_none(mode_node, 'qcom,compression-mode')
+		self.has_dsc = self.compression_mode is not None and self.compression_mode.as_str() == "dsc"
+
+		if self.has_dsc:
+			#self.dsc_lm_split = fdt.getprop_or_none(mode_node, 'qcom,lm-split')
+			dsc_encoders = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-encoders')
+			self.dsc_encoders = dsc_encoders.as_int32() if dsc_encoders else None
+
+			dsc_slice_height = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-slice-height')
+			self.dsc_slice_height = dsc_slice_height.as_int32() if dsc_slice_height else None
+
+			dsc_slice_width = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-slice-width')
+			self.dsc_slice_width = dsc_slice_width.as_int32() if dsc_slice_width else None
+
+			dsc_slice_per_pkt = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-slice-per-pkt')
+			self.dsc_slice_per_pkt = dsc_slice_per_pkt.as_int32() if dsc_slice_per_pkt else None
+
+			dsc_bit_per_component = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-bit-per-component')
+			self.dsc_bit_per_component = dsc_bit_per_component.as_int32() if dsc_bit_per_component else None
+
+			dsc_bit_per_pixel = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-bit-per-pixel')
+			self.dsc_bit_per_pixel = dsc_bit_per_pixel.as_int32() if dsc_bit_per_pixel else None
+
+			# Boolean
+			self.dsc_dsc_block_prediction = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-block-prediction-enable')
+
+			dsc_version = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-version')
+			self.dsc_version = dsc_version.as_int32() if dsc_version else None
+
+			dsc_scr_version = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-scr-version')
+			self.dsc_scr_version = dsc_scr_version.as_int32() if dsc_scr_version else None
+
 	@staticmethod
 	def parse(fdt: Fdt2, node: int) -> Panel:
 		name = fdt.getprop_or_none(node, 'qcom,mdss-dsi-panel-name')

--- a/panel.py
+++ b/panel.py
@@ -325,8 +325,8 @@ class Panel:
 			self.dsc_bit_per_pixel = fdt.getprop(mode_node, 'qcom,mdss-dsc-bit-per-pixel').as_uint32()
 			self.dsc_block_prediction = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-block-prediction-enable') is not None
 
-			self.dsc_version = fdt.getprop_uint32(mode_node, 'qcom,mdss-dsc-version', default=1)
-			self.dsc_scr_version = fdt.getprop_uint32(mode_node, 'qcom,mdss-dsc-scr-version', default=1)
+			self.dsc_version = fdt.getprop_uint32(mode_node, 'qcom,mdss-dsc-version', default=0x11)
+			self.dsc_scr_version = fdt.getprop_uint32(mode_node, 'qcom,mdss-dsc-scr-version', default=0)
 
 	@staticmethod
 	def parse(fdt: Fdt2, node: int) -> Panel:

--- a/panel.py
+++ b/panel.py
@@ -332,14 +332,13 @@ class Panel:
 			dsc_bit_per_pixel = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-bit-per-pixel')
 			self.dsc_bit_per_pixel = dsc_bit_per_pixel.as_int32() if dsc_bit_per_pixel else None
 
-			# Boolean
-			self.dsc_dsc_block_prediction = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-block-prediction-enable')
+			self.dsc_dsc_block_prediction = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-block-prediction-enable') is not None
 
 			dsc_version = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-version')
-			self.dsc_version = dsc_version.as_int32() if dsc_version else None
+			self.dsc_version = dsc_version.as_int32() if dsc_version else 1
 
 			dsc_scr_version = fdt.getprop_or_none(mode_node, 'qcom,mdss-dsc-scr-version')
-			self.dsc_scr_version = dsc_scr_version.as_int32() if dsc_scr_version else None
+			self.dsc_scr_version = dsc_scr_version.as_int32() if dsc_scr_version else 1
 
 	@staticmethod
 	def parse(fdt: Fdt2, node: int) -> Panel:


### PR DESCRIPTION
Just a draft for now to raise awareness about the existence of these patches, making sure existing progress is not forgotten about. I have just taken @jenneron's original DSC patch and fixed up the broken conventions in the exact same way as the upstream DPU1 driver (https://lore.kernel.org/linux-arm-msm/20221026182824.876933-1-marijn.suijten@somainline.org/). Conflicts need to be solved in a rebase and a real-world DSC panel should be tested by someone who actually uses the panel generator, rather than by me who only gets sent broken drivers generated by it and is in turn expected to "fix them plox".