### PR TITLE
panel: support bl_ctrl_dcs_l backlight type

### DIFF
--- a/panel.py
+++ b/panel.py
@@ -226,7 +226,11 @@ class Panel:
 		self.traffic_mode = TrafficMode.parse(fdt.getprop(node, 'qcom,mdss-dsi-traffic-mode'))
 
 		backlight = fdt.getprop_or_none(node, 'qcom,mdss-dsi-bl-pmic-control-type')
-		self.backlight = BacklightControl(backlight.as_str()) if backlight else None
+		# FIXME https://android.googlesource.com/kernel/msm/+/52edb91eb65ab5e84fd98061057d3ffa2074ffc1
+		backlight_str = backlight.as_str()
+		if backlight_str == "bl_ctrl_dcs_l":
+			backlight_str = "bl_ctrl_dcs"
+		self.backlight = BacklightControl(backlight_str) if backlight else None
 		self.max_brightness = fdt.getprop_uint32(node, 'qcom,mdss-dsi-bl-max-level', None)
 		if self.backlight == BacklightControl.DCS and self.max_brightness is None:
 			print("WARNING: DCS backlight without maximum brightness, ignoring...")


### PR DESCRIPTION
As seen on lg-lenok lgd_lg4237_cmd panel.

---

Obviously a very bad draft for now. As seen in https://android.googlesource.com/kernel/msm/+/52edb91eb65ab5e84fd98061057d3ffa2074ffc1 to handle it properly we'd need to add a new variant of `mipi_dsi_dcs_set_display_brightness` that has a payload of 3 bytes, with a zero byte at the end. Curiously setting backlight brightness seems to work correctly with this variant on lenok also. Need to test if any behavior changes with the "long" command variant.