### PR TITLE
driver: Always call set_tear_on on CMD mode panels

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -7,7 +7,7 @@ import mipi
 import simple
 import wrap
 from generator import Options, GpioFlag
-from panel import Panel, BacklightControl, CommandSequence, CompressionMode
+from panel import Panel, BacklightControl, CommandSequence, CompressionMode, Mode
 
 
 def generate_includes(p: Panel, options: Options) -> str:
@@ -139,6 +139,15 @@ static int {p.short_id}_{cmd_name}(struct {p.short_id} *ctx)
 		s += c.generated + '\n'
 		if c.wait and c.wait > options.ignore_wait:
 			s += f'\t{msleep(c.wait)};\n'
+
+	if cmd_name == 'on' and p.mode == Mode.CMD_MODE:
+		s += '''
+	ret = mipi_dsi_dcs_set_tear_on(ctx->dsi, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set tear on: %d\\n", ret);
+		return ret;
+	}
+'''
 
 	s += '''
 	return 0;


### PR DESCRIPTION
The downstream msm-4.9 driver is unconditinally calling mdss_dsi_set_tear_on with command mode panels, replicate the same in the driver generator.

When this doesn't get enabled then the panel doesn't generate any Tearing Effect output signal which is used by MDSS.

See downstream: https://gerrit-public.fairphone.software/plugins/gitiles/kernel/msm-4.9/+/refs/heads/int/13/fp3/drivers/video/fbdev/msm/mdss_dsi.c#1776
This is observed with the following panel: https://gerrit-public.fairphone.software/plugins/gitiles/kernel/msm-4.9/+/refs/heads/int/13/fp3/arch/arm64/boot/dts/qcom/dsi-hx83112b-djn-1080p-cmd.dtsi (seen by the panel being stuck at 30Hz instead of 60Hz)

---

**Draft:** Not sure though if this solution is acceptable / good for any cmd mode panel. I'm assuming most already call this during the _on commands.

Also probably we should also call `mipi_dsi_dcs_set_tear_off` during _off, since downstream also calls this there (see the mdss_dsi.c file above with `mdss_dsi_set_tear_off`)?