### PR TITLE
Emit MIPI DSI Picture Parameter Set command

### DIFF
--- a/mipi.py
+++ b/mipi.py
@@ -224,6 +224,14 @@ def _generate_compression_mode(t: Transaction, payload: bytes, options: Options)
 								  'set compression mode')
 
 
+def _generate_picture_parameter_set(t: Transaction, payload: bytes, options: Options) -> str:
+	text = f'\t// TODO: Autogenerate `struct drm_dsc_picture_parameter_set` via `drm_dsc_pps_payload_pack()`\n'
+	text += wrap.join(f'\tconst u8 pps[{hex(len(payload))}] = {{', ',', '};\n', _get_params_hex(payload), force=0)
+
+	return text + _generate_checked_call('mipi_dsi_picture_parameter_set', ['dsi', '(const struct drm_dsc_picture_parameter_set *)pps'],
+								  'picture parameter set')
+
+
 def _generate_ignore(t: Transaction, payload: bytes, options: Options) -> str:
 	print(f"WARNING: Ignoring weird {t.name}")
 	return f"\t// WARNING: Ignoring weird {t.name}"
@@ -270,7 +278,7 @@ class Transaction(Enum):
 	GENERIC_LONG_WRITE = 0x29, -1, _generate_generic_write
 	DCS_LONG_WRITE = 0x39, -1, _generate_dcs_write
 
-	PICTURE_PARAMETER_SET = 0x0a,
+	PICTURE_PARAMETER_SET = 0x0a, -1, _generate_picture_parameter_set
 	COMPRESSED_PIXEL_STREAM = 0x0b,
 
 	LOOSELY_PACKED_PIXEL_STREAM_YCBCR20 = 0x0c,


### PR DESCRIPTION
Draft.  This is not something I think we should actually send, since the PPS send command is already emitted if `qcom,compression-mode = <DSC>;`.  However, if the PPS is present in device DTSI, I do want to make the user aware that it exists and give them a way to compare it with whatever the automated `mipi_dsi_picture_parameter_set()` sends.

Note that this PPS is built up partially by the panel driver, and then further filled in by `drm/msm` drivers _and_ DRM DSC helpers.  Hence differences might sometimes be key in debugging a DSC setup.

For now the PPS could be emitted to the kernel log with the following snippet, but before going ahead and emitting a print for both, does anyone know of a proper way to diff or compare and print the result instead?

```c
       print_hex_dump(KERN_INFO, "DSC:", DUMP_PREFIX_NONE, 16,
                      1, (void *)&pps, sizeof(pps), false);
```
