### PR TITLE
Use container_of_const

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -544,7 +544,7 @@ def generate_driver(p: Panel, options: Options) -> None:
 
 {wrap.simple([f'static inline', f'struct {p.short_id} *to_{p.short_id}(struct drm_panel *panel)'])}
 {{
-	return container_of(panel, struct {p.short_id}, panel);
+	return container_of_const(panel, struct {p.short_id}, panel);
 }}
 {generate_reset(p, options)}
 {generate_commands(p, options, 'on')}


### PR DESCRIPTION
include/linux/container_of.h recommends using `container_of_const` in any new code instead of `container_of`
There's discussion about it here: https://lore.kernel.org/all/20250520103437.468691-1-sakari.ailus@linux.intel.com/#t