### PR TITLE
lk: panel: Add 10-BIT panel generation support and add "bl_ctrl_external" backlight type

### DIFF
--- a/lk.py
+++ b/lk.py
@@ -26,8 +26,8 @@ def generate_commands(p: Panel, cmd_name: str) -> str:
 			b.append(next(itr, 0))
 			b.append(next(itr, 0))
 
-		b.append(c.type.value | c.vc << 6)
-		b.append(int(c.ack) << 5 | int(long) << 6 | int(c.last) << 7)
+		b.append((c.type.value & 0x3f) | ((c.vc & 0x03) << 6))
+		b.append(((int(c.ack) & 1) << 5) | ((int(long) & 1) << 6) | ((int(c.last) & 1) << 7))
 
 		if long:
 			b += bytes(c.payload)

--- a/panel.py
+++ b/panel.py
@@ -281,6 +281,8 @@ class Panel:
 
 		if self.bpp == 24:
 			self.format = 'MIPI_DSI_FMT_RGB888'
+		elif self.bpp == 30:
+			self.format = 'MIPI_DSI_FMT_RGB101010'
 		else:
 			raise ValueError(f'Unsupported bpp: {self.bpp} (TODO)')
 

--- a/panel.py
+++ b/panel.py
@@ -96,7 +96,7 @@ class BacklightControl(Enum):
 	DCS = 'bl_ctrl_dcs'
 	WLED = 'bl_ctrl_wled'
 	SAMSUNG_PWM = 'bl_ctrl_ss_pwm'
-
+	EXTERNAL = 'bl_ctrl_external'
 
 @unique
 class CompressionMode(Enum):


### PR DESCRIPTION
While generating panels from given DTBs on newer devices with 10-BIT panels, generator throws out a traceback:

```
...
Parsing: panel_bale_p_7_ab715_dsc_cmd (P 7 AB715 dsc cmd mode panel)
WARNING: Multiple display timings are not supported yet, using first!
Traceback (most recent call last):
  File "/local/mnt/workspace/linux-mdss-dsi-panel-driver-generator/./lmdpdg.py", line 77, in <module>
    panel = Panel.parse(fdt, offset)
  File "/local/mnt/workspace/linux-mdss-dsi-panel-driver-generator/panel.py", line 335, in parse
    return name and Panel(name.as_str(), fdt, node)
                    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local/mnt/workspace/linux-mdss-dsi-panel-driver-generator/panel.py", line 285, in __init__
    raise ValueError(f'Unsupported bpp: {self.bpp} (TODO)')
ValueError: Unsupported bpp: 30 (TODO)
...
```

This PR should add support.